### PR TITLE
block processing for jekyll build in test-web

### DIFF
--- a/scripts/test-web.sh
+++ b/scripts/test-web.sh
@@ -7,11 +7,10 @@ set -e
 jekyllTrap="echo 'Killing jekyll...' && pkill -f jekyll"
 trap "$jekyllTrap" ERR INT
 
-if [[ "$@" == *"--skip-initial-build"* ]]; then
-    bundle exec jekyll serve --detach --skip-initial-build
-else
-    bundle exec jekyll serve --detach
+if [[ "$@" != *"--skip-initial-build"* ]]; then
+    bundle exec jekyll build
 fi
+bundle exec jekyll serve --detach --skip-initial-build
 
 if [[ "$@" != *"--skip-npm-build"* ]]; then
     npm run build


### PR DESCRIPTION
detach causes it to run in background and nightwatch tests could start before the site is being served. This will be a blocking approach that will finish the build entirely before continuing execution