### PR TITLE
DX-414: Fix Markdown List Class

### DIFF
--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -22,6 +22,11 @@ ul {
     }
 }
 
+.markdown-description > ul {
+    padding-left: 40px;
+    list-style-type: disc;
+}
+
 .font-normal {
     font-weight: normal;
     letter-spacing: normal;
@@ -124,4 +129,4 @@ h5 {
     letter-spacing: 0.07em;
     line-height: 14px;
 }
- 
+

--- a/dynamic/react/api-app/components/apiDescription.jsx
+++ b/dynamic/react/api-app/components/apiDescription.jsx
@@ -13,7 +13,7 @@ const mapStateToProps = (state) => (
 const ApiDescRender = ({apiName, apiDescription}) => (
     <div className={'api-summary'}>
         <h1>{apiName}</h1>
-        <ReactMarkdown source={apiDescription || ''} />
+        <ReactMarkdown className={'markdown-description'} source={apiDescription || ''} />
         <h2>{'Api Reference'}</h2>
         <p>{'Full reference for this API is available on the developer site:'}</p>
         <ul>

--- a/dynamic/react/api-app/components/apiDocumentation.jsx
+++ b/dynamic/react/api-app/components/apiDocumentation.jsx
@@ -49,7 +49,7 @@ const ApiDocumentation = ({endpoint}) => (
             </thead>
         </table>
         <h3 id='description'>{'Description'}</h3>
-        <ReactMarkdown source={endpoint.description || ''} />
+        <ReactMarkdown className={'markdown-description'} source={endpoint.description || ''} />
         <h3 id='parameters'>{'Parameters'}</h3>
         <table className='styled-table'>
             <thead>

--- a/dynamic/react/api-app/components/apiDocumentationParam.jsx
+++ b/dynamic/react/api-app/components/apiDocumentationParam.jsx
@@ -19,7 +19,7 @@ const ApiDocumentationParam = ({params, type, currentOperation}) => (
                     {', '}
                     {(params[param].enum) ? 'Enum' : params[param].fieldType}
                 </td>
-                <td><ReactMarkdown source={params[param].description || ''} /></td>
+                <td><ReactMarkdown className={'markdown-description'} source={params[param].description || ''} /></td>
             </tr>);
         })}
     </tbody>

--- a/dynamic/swagger-to-api-doc.js
+++ b/dynamic/swagger-to-api-doc.js
@@ -63,7 +63,7 @@ const saveMethodsIndex = (apiName, saveRoot, product, linksArray, methodSubsetNa
 <tr>
     <td><a href="/${encodeURIComponent(l.link)}">${l.name}</a></td>
     <td>{{"${l.summary || ''}"}}</td>
-    <td>{{"${(l.description || '').replace(/"/g, "'")}" | markdownify}}</td>
+    <td class='markdown-description'>{{"${(l.description || '').replace(/"/g, "'")}" | markdownify}}</td>
 </tr>`;
     }, '');
 


### PR DESCRIPTION
Ticket: https://avalara.atlassian.net/browse/DX-414

Fixed the list class for the markdown descriptions. Any future lists created inside/with the markdown should receive this `normal` bullet class.