### PR TITLE
Fixing the image

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,8 @@
     <meta property="og:url" content="https://developer.avalara.com/" />
     <meta property="og:site_name" content="Avalara Developer Network" />
     <meta property="og:description" content="{{ page.ogdescription | default:default_desc }}"/>
-
+    <meta property="og:image" content="{{ page.ogimage }}">
+    
     <link rel="apple-touch-icon" sizes="57x57" href="/public/images/favicon/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/public/images/favicon/apple-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="/public/images/favicon/apple-icon-72x72.png">

--- a/_posts/2017-10-18-adjusting-transactions.md
+++ b/_posts/2017-10-18-adjusting-transactions.md
@@ -2,6 +2,7 @@
 layout: post
 title: Adjusting Transactions
 description: Adjusting Transactions
+ogimage: "/images/adjusting3.png"
 date: 2017-10-10 12:00
 author: Mark Withers
 comments: true


### PR DESCRIPTION
This added a meta tag to the default page so that if you add an image into the heading of the markdown, that is the page that is displayed when you post the article to social media.