### PR TITLE
RSS feed for patch notes

### DIFF
--- a/feed-patch.xml
+++ b/feed-patch.xml
@@ -1,0 +1,28 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title | xml_escape }}</title>
+    <description>{{ site.description | xml_escape }}</description>
+    <link>{{ site.url }}{{ site.baseurl }}/</link>
+    <atom:link href="{{ "/feed-patch.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+    {% for post in site.categories["patch notes"] %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        <description>{{ post.content | xml_escape }}</description>
+        <pubDate>{{ post.date | date: "%Y-%m-%d" }}</pubDate>
+        <link>{{ post.url | prepend: site.baseurl | prepend: host }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: host }}</guid>
+        {% for tag in post.tags %}
+        <category>{{ tag | xml_escape }}</category>
+        {% endfor %}
+        {% for cat in post.categories %}
+        <category>{{ cat | xml_escape }}</category>
+        {% endfor %}
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
This creates an RSS feed for patch notes that will be used for subscribing to only patch notes. This is the first step to completing this ticket: https://jira.avalara.com/browse/DEVCON-2631, which asks for a subscription to patch notes. 