### PR TITLE
reverting back the webinar page

### DIFF
--- a/public/js/site.js
+++ b/public/js/site.js
@@ -30,14 +30,14 @@ $(document).ready(function()
     fixDropDownMenuLargePosition();
 
     $('[webinar-hide-before]').each(function() {
-      if ($(this).attr('webinar-hide-before') <= getCompareDate()) {
-        $(this).show();
+      if ($(this).attr('webinar-hide-before') > getCompareDate()) {
+        $(this).hide();
       }
     });
 
     $('[webinar-hide-after]').each(function() {
-      if ($(this).attr('webinar-hide-after') > getCompareDate()) {
-        $(this).show();
+      if ($(this).attr('webinar-hide-after') <= getCompareDate()) {
+        $(this).hide();
       }
     });
 

--- a/resources/recordings.html
+++ b/resources/recordings.html
@@ -7,7 +7,7 @@ product: webinars
 <div class="container">
   <div class="row">
     {% for post in site.webinars reversed %}
-      <div webinar-hide-before="{{ post.date | date: '%Y%m%d' }}" class="col-md-5" hidden>
+      <div webinar-hide-before="{{ post.date | date: '%Y%m%d' }}" class="col-md-5">
         <div class="blog-preview">
           <div class="gradient"></div>
           <h4><a href="{{ post.url }}">{{ post.title }}</a></h4>

--- a/resources/webinars.html
+++ b/resources/webinars.html
@@ -7,7 +7,7 @@ product: webinars
 <div class="container">
   <div class="row">
     {% for post in site.webinars %}
-      <div webinar-hide-after="{{ post.date | date: '%Y%m%d' }}"  class="col-md-5" hidden>
+      <div webinar-hide-after="{{ post.date | date: '%Y%m%d' }}"  class="col-md-5">
         <div class="blog-preview">
           <div class="gradient"></div>
           <h4><a href="{{ post.url }}">{{ post.title }}</a></h4>


### PR DESCRIPTION
Looks like the previous PR does not work and caused all of the webinars to disappear, even though it was working locally.  I am planning to look into this more but thought we should revert while it is being fixed. 