### PR TITLE
Update Communications Content

### DIFF
--- a/_data/api_consoles/communications.yml
+++ b/_data/api_consoles/communications.yml
@@ -7,5 +7,4 @@ nav_link:
 nav_links:
   - title: Overview
     path: /communications
-  - title: API reference
-    path: /api-reference/communications/afc-rest
+  

--- a/_includes/certification_navigation.html
+++ b/_includes/certification_navigation.html
@@ -25,7 +25,7 @@
             </div>
         {% endif %}
     </li>
-    <li {% if page.url == "/certification/communications-certification/" %}class="active"{% endif %}><a href="/certification/communications-certification/">Avalara Communications</a></li>
+    <li {% if page.url == "/certification/communications/" %}class="active"{% endif %}><a href="/certification/communications/">Avalara Communications</a></li>
     <li {% if page.url == "/certification/excise/" %}class="active"{% endif %}><a href="/certification/excise/">Avalara Excise</a></li>
     <li {% if page.url == "/certification/certcapture/" %}class="active"{% endif %}><a href="/certification/certcapture/">Avalara CertCapture</a></li>
 </ul>
@@ -33,7 +33,7 @@
     <button id="use-case-nav" type="button" data-toggle="dropdown">Certifications</button>
     <ul class="dropdown-menu" aria-labelledby="use-case-nav">
         <li><a href="/certification/avatax/">Avalara AvaTax</a></li>
-        <li><a href="/certification/communications-certification/">Avalara Communications</a></li>
+        <li><a href="/certification/communications/">Avalara Communications</a></li>
         <li><a href="/certification/excise/">Avalara Excise</a></li>
         <li><a href="/certification/certcapture/">Avalara CertCapture</a></li>
     </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -144,8 +144,14 @@
                             <li><a target="_blank" href="https://www.npmjs.com/package/avatax">Install JavaScript SDK via NPMJS</a></li>
                         </ul>
                     </li>
-                    <li class="tests"><a href="/tests/testing-your-integration/"><span class="text-uppercase">Tests</span></a></li>
-                    <!-- removing until the link to the Self-Test is fugured out -->
+                    <li class="tests dropdown dropdown-large hidden-xs">
+                        <a class="dropdown-toggle" data-toggle="dropdown"><span class="text-uppercase">Tests</span> <b class="caret"></b></a>
+                        <ul class="dropdown-menu dropdown-menu-large">
+                            <li><a href="/tests/testing-your-integration/">Avalara Test Cases</a></li>
+                            <li><a href="/tests/communications-test">Avalara for Communications Test Cases</a></li>
+
+                        </ul>
+                    </li>                    <!-- removing until the link to the Self-Test is fugured out -->
                     <!--
                     <li class="tests dropdown dropdown-large hidden-xs">
                         <a class="dropdown-toggle" data-toggle="dropdown"><span class="text-uppercase">Tests</span> <b class="caret"></b></a>
@@ -160,7 +166,7 @@
                         <ul class="dropdown-menu dropdown-menu-large">
                             <li><a href="/certification/">Overview</a></li>
                             <li><a href="/certification/avatax/">Avalara AvaTax</a></li>
-                            <li><a href="/certification/communications-certification/">Avalara Communications</a></li>
+                            <li><a href="/certification/communications/">Avalara Communications</a></li>
                             <li><a href="/certification/excise/">Avalara Excise</a></li>
                             <li><a href="/certification/certcapture/">Avalara CertCapture</a></li>
                         </ul>

--- a/communications/index.md
+++ b/communications/index.md
@@ -42,7 +42,7 @@ doctype: overview
             </div>
             <div class="col-md-7 col-md-offset-5 padding-top">
                 <ul>
-                    <li><a href="https://github.com/Avalara/Avalara-Communications-SaaS-Pro" target="_blank">API documentation</a></li>
+                    <li><a href="https://github.com/Avalara/Communications-Developer-Content/" target="_blank">API documentation</a></li>
                     <li><a href="/api-reference/communications/afc-rest">API reference</a></li>
                 </ul>
             </div>

--- a/communications/index.md
+++ b/communications/index.md
@@ -43,7 +43,6 @@ doctype: overview
             <div class="col-md-7 col-md-offset-5 padding-top">
                 <ul>
                     <li><a href="https://github.com/Avalara/Communications-Developer-Content/" target="_blank">API documentation</a></li>
-                    <li><a href="/api-reference/communications/afc-rest">API reference</a></li>
                 </ul>
             </div>
             <div class="col-md-7 col-md-offset-5 padding-top">

--- a/tests/communications-test.md
+++ b/tests/communications-test.md
@@ -1,21 +1,10 @@
 ---
 layout: page
-title: Communications Certification
+title: Avalara for Communications Test Cases
 product: communications
-doctype: integration_checklists
-nav: certification
+doctype: test_your_integration
+nav: tests
 ---
-
-<style>
-.styled-table {
-  border-collapse: collapse;}
-  .styled-table tbody {
-    background-color: #f5f6fa; }
-    .styled-table tbody td {
-      border-top: 1px solid #ffff; }
-  .styled-table tbody {
-    background-color: #ffffff; }
-</style>
 
 Depending on the scope of your integration and your business practice, your test cases
 will vary. For development partners, many of these are requirements for certification. If


### PR DESCRIPTION
Placed the Communications Test Cases, under the Test navigation menu.
Updated the Certification link to point  to the certification requirements instead of the test cases. 
Updated link to Communications Github documentation.