### PR TITLE
Fixed createCertificate page not rendering issue

### DIFF
--- a/dynamic/swagger/avatax/rest/v2.json
+++ b/dynamic/swagger/avatax/rest/v2.json
@@ -24307,22 +24307,6 @@
           "readOnly": true,
           "example": 0
         },
-        "customers": {
-          "description": "A list of customers to which this certificate applies.  You can fetch this data by specifying\r\n`$include=customers` when calling a certificate fetch API.",
-          "type": "array",
-          "items": {
-          },
-          "example": [
-            {
-              "companyId": 0,
-              "customerCode": "2259be11-c340-44a9-abd6-4fb0dbe4ce14"
-            },
-            {
-              "companyId": 0,
-              "customerCode": "e01155f6-1872-4363-be95-cd345b06d20b"
-            }
-          ]
-        },
         "poNumbers": {
           "description": "A list of purchase order numbers that are valid for use with this certificate.\r\n\r\nIf this certificate is applicable for all purchase order numbers, this field will be empty.\r\n\r\nYou can fetch this data by specifying `$include=ponumbers` when calling a certificate fetch API.",
           "type": "array",


### PR DESCRIPTION
The customer property wasn't removed properly when resolving the circular reference, causing the createCertificate page to not have content. This solves the issue.