### PR TITLE
DEVCON2702

### DIFF
--- a/dynamic/swagger-to-api-doc.js
+++ b/dynamic/swagger-to-api-doc.js
@@ -93,7 +93,7 @@ const saveMethodsIndex = (apiName, saveRoot, product, linksArray, methodSubsetNa
 <tr>
     <td><a href="/${encodeURIComponent(l.link)}">${l.name}</a></td>
     <td>{{"${l.summary || ''}"}}</td>
-    <td class='markdown-description'>{{"${(l.description || '').replace(/"/g, "'")}" | markdownify}}</td>
+    <td class='markdown-description'>{{"${(l.description || '').replace(/"/g, "'").split(/(\.)/)[0]}." | markdownify}}</td>
 </tr>`;
         }
         return `${accum}`;


### PR DESCRIPTION
reduced excessive text on API category pages, taking the first sentence of method's description on Swagger rather than the entire description for method description on API category pages. 