### PR TITLE
Hot fix end to end test failure

### DIFF
--- a/dynamic/react/api-app/index.js
+++ b/dynamic/react/api-app/index.js
@@ -6,7 +6,8 @@ import createLogger from 'redux-logger';
 import {Provider} from 'react-redux';
 import userManager from './user-manager';
 
-import Oidc from 'oidc-client';
+// import Oidc from 'oidc-client';
+const Oidc = require('oidc-client');
 
 import reducer from './reducers/reducer';
 import App from './app';


### PR DESCRIPTION
Updated oidc no longer support ES6 import syntax, thus causing improper import of oidc npm module.