### PR TITLE
DEVCON-3479: redirect Patch Notes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -191,7 +191,7 @@
                         <ul class="dropdown-menu dropdown-menu-large">
                           <li><a href="/resources/conferences">Avalara CRUSH Conference</a></li>
                           <li><a href="https://avalaracommunity.force.com/partnerlaunch" target="_blank">Avalara Launch Center</a></li>
-                          <li><a href="/blog/patch-notes">API Patch Notes</a></li>
+                          <li><a href="https://www.avalara.com/us/en/blog/category/patch-updates.html">API Patch Notes</a></li>
                           <li><a href="https://www.avalara.com/us/en/blog/category/developer.html">Developer Blog</a></li>
                           <li><a href="/resources/support">Developer Support Options</a></li>
                           <li><a href="https://community.avalara.com/avalara/category_sets/developers">Help Forum</a></li>
@@ -201,7 +201,7 @@
                     </li>
                     <li class="resources visible-xs-block"><a href="/resources/conferences"><span class="text-uppercase">Avalara CRUSH Conference</span></a></li>
                     <li class="resources visible-xs-block"><a href="https://avalaracommunity.force.com/partnerlaunch"><span class="text-uppercase">Avalara Launch Center</span></a></li>
-                    <li class="resources visible-xs-block"><a href="/blog/patch-notes"><span class="text-uppercase">API Patch Notes</span></a></li>
+                    <li class="resources visible-xs-block"><a href="https://www.avalara.com/us/en/blog/category/patch-updates.html"><span class="text-uppercase">API Patch Notes</span></a></li>
                     <li class="resources visible-xs-block"><a href="https://www.avalara.com/us/en/blog/category/developer.html"><span class="text-uppercase">Developer Blog</span></a></li>
                     <li class="resources visible-xs-block"><a href="/resources/support"><span class="text-uppercase">Developer Support Options</span></a></li>
                     <li class="resources visible-xs-block"><a href="https://community.avalara.com/avalara/category_sets/developers"><span class="text-uppercase">Help Forum</span></a></li>


### PR DESCRIPTION
https://jira.avalara.com/browse/DEVCON-3479

Redirecting the Patch Notes links to new blog.