### PR TITLE
Geo Soap Error page fix

### DIFF
--- a/_includes/dev-guide_comms_navigation_geo_soap.html
+++ b/_includes/dev-guide_comms_navigation_geo_soap.html
@@ -61,8 +61,7 @@
                         <li><a href="/communications/dev-guide_geo_soap/reference/fault">Fault</a></li>
                     </ol>
                 </li>
-                <li><a href="/communications/dev-guide_geo_soap/reference/errors/index">Errors</a></li>
-                <!--<li>Errors</li>-->
+                <li><a href="/communications/dev-guide_geo_soap/reference/errors/">Errors</a></li>
             </ol>
             {% endif %}
         </li>


### PR DESCRIPTION
Fix nav file to go to /reference/errors instead of /reference/errors/index

![image](https://user-images.githubusercontent.com/17029919/53983920-dced4c80-40dd-11e9-9891-ab525ee6dfa8.png)
