### PR TITLE
Fixed links on main page

### DIFF
--- a/communications/index.md
+++ b/communications/index.md
@@ -42,8 +42,8 @@ doctype: overview
             </div>
             <div class="col-md-7 col-md-offset-5 padding-top">
                 <ul>
-                    <li><a href="/communications/dev-guide_rest_v2/index/" target="_blank">AFC REST v2 Developer Guide</a></li>
-                    <li><a href="/communications/dev-guide_geo_soap/index/" targe="_blank">AFC Geo Soap Developer Guide</a></li>
+                    <li><a href="/communications/dev-guide_rest_v2/" target="_blank">AFC REST v2 Developer Guide</a></li>
+                    <li><a href="/communications/dev-guide_geo_soap/" targe="_blank">AFC Geo Soap Developer Guide</a></li>
                 </ul>
             </div>
             <div class="col-md-7 col-md-offset-5 padding-top">


### PR DESCRIPTION
Fixed links on main page to remove "index/".  Works locally with index included, but not in Prod - Page not Found error

![image](https://user-images.githubusercontent.com/17029919/54838732-54eb7300-4c97-11e9-8372-767fb18534d8.png)
