### PR TITLE
May Comms REST v2 updates

### DIFF
--- a/communications/dev-guide_rest_v2/customizing-transactions/bundle-file.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/bundle-file.md
@@ -68,7 +68,7 @@ Version,3.0.0
 <h3>Using the Bundle file</h3>
 The Bundle file is applied to a <a class="dev-guide-link" href="#request">client profile</a>.  You must pass the associated <code>client_profile_id</code> as part of the header to use the Bundle file.
 <br/>
-Create a transaction using the Bundle Transaction ID and Bundle Service ID (<code>tran</code> is 20000 and <code>serv</code> is 20001 for this example) and specify the sale amount (<code>).
+Create a transaction using the Bundle Transaction ID and Bundle Service ID (<code>tran</code> is 20000 and <code>serv</code> is 20001 for this example) and specify the sale amount (<code>chg</code>).
 
 {% highlight json %}
 {
@@ -110,7 +110,10 @@ Create a transaction using the Bundle Transaction ID and Bundle Service ID (<cod
 }
 {% endhighlight %}
 
-<h4 id="request">Requesting a new client profile or changes to an existing client profile</h4>
+<h4>Note about Bundle File Results</h4>
+Bundled tax calculations return summarized <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/detailed-tax-result">detailed results</a> (<code>txs</code>) when more than one bundle item returns the same tax type.
+
+<h3 id="request">Requesting a new client profile or changes to an existing client profile</h3>
 Contact <a class="dev-guide-link" href="mailto:CommunicationSupport@avalara.com">CommunicationSupport@avalara.com</a>:
 <ol class="dev-guide-list">
   <li>Request the customization files and configurations.  Attach existing <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/customizing-transactions/account-customizations/">customization files</a> to the email</li>

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/displaying-tax-results.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/displaying-tax-results.md
@@ -50,6 +50,9 @@ Setting the ReturnDetail flag (<code>dtl</code>) displays or hides the detailed 
   </table>
 </div>
 
+<h5>Note about Bundle Files</h5>
+Bundled tax calculations return summarized <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/detailed-tax-result">detailed results</a> when more than one bundle item returns the same tax type.
+
 <h4>ReturnSummary</h4>
 Setting the ReturnSummary flag (<code>summ</code>) displays or hides the summary taxes object (<code>summ</code>) for the entire Invoice in the <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/calc-taxes-response/">CalcTaxes response</a>.
 
@@ -172,7 +175,7 @@ This is the only combination of fields to return both the Detail and Summary tax
 Detailed taxes (<code>txs</code>) and Summarized taxes (<code>summ</code>) are both returned.
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse1">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse1">View the Response JSON</a>
   <div id="collapse1" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}
@@ -679,7 +682,7 @@ The following additional scenarios return the same results:
 Only Detailed taxes (<code>txs</code>) are returned.
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse2">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse2">View the Response JSON</a>
   <div id="collapse2" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}
@@ -992,7 +995,7 @@ This is the only combination of fields to return only Summary taxes.
 Only Summarized taxes (<code>summ</code>) are returned.
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse3">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse3">View the Response JSON</a>
   <div id="collapse3" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/jurisdiction-determination.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/jurisdiction-determination.md
@@ -74,6 +74,23 @@ When specifying jurisdictions outside of the United States via country/state/cou
 
 See <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/location/">Location</a> for more information.
 
+<h3>Zip-Only Fallback</h3>
+If the city or county name does not match and a postal code is provided, jurisdiction determination falls back to the Zip Code for transactions in the United States of America or Canada.
+<ul class="dev-guide-list">
+  <li>USA: 5 or 9 digit Zip Codes.  For example, 95054 or 95054-1234</li>  
+  <li>Canada: 6 byte Postal Code with or without a dash.  For example, T4X-1Y6 or T4X1Y6 </li>
+</ul>
+
+Full state and country names are also supported, along with the 2 character state abbreviation or 3 character ISO country code.
+<ul class="dev-guide-list">
+  <li>Alaska or AK</li>
+  <li>Quebec or QC</li>
+  <li>Switzerland or CHE</li>
+  <li>United State of America or USA</li>
+</ul>
+
+The fallback process ignores spacing and punctuation in the city and county names.  For example, “CURRY'S CORNER”, AK is treated the same as “CURRYS CORNER” and “CURRYSCORNER”.
+
 <h3 id="us_geo">United States Tax Request using Geocoding Example</h3>
 Geocoding functionality is being used in this example by setting <code>geo</code> to <code>true</code> and specifying an address (<code>addr</code>), city (<code>city</code>), state (<code>st</code>), postal code (<code>zip</code>), and country (<code>ctry</code>).
 
@@ -154,7 +171,7 @@ Geocoding functionality is being used in this example by setting <code>geo</code
 Federal, State, and County taxes are returned based upon the geocoding request.
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse1">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse1">View the Response JSON</a>
   <div id="collapse1" class="panel-collapse collapse">
     <div class="panel-body">
 
@@ -617,7 +634,7 @@ This example sets the BillTo <a class="dev-guide-link" href="/communications/dev
 Taxes returned are for Quebec (tax level <code>lvl</code> 1) and Canada (tax level <code>lvl</code> 0).
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse2">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse2">View the Response JSON</a>
   <div id="collapse2" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/jurisdiction-determination.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/jurisdiction-determination.md
@@ -91,6 +91,9 @@ Full state and country names are also supported, along with the 2 character stat
 
 The fallback process ignores spacing and punctuation in the city and county names.  For example, “CURRY'S CORNER”, AK is treated the same as “CURRYS CORNER” and “CURRYSCORNER”.
 
+<h4>Pro Tip</h4>
+Specify a PCode for fallback when using the embedded Geocoding functionality (<code>geo</code> = <code>true</code> in a <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/location">location</a>).  If geocoding fails to find the location, the PCode is used in the zip-only fallback.
+
 <h3 id="us_geo">United States Tax Request using Geocoding Example</h3>
 Geocoding functionality is being used in this example by setting <code>geo</code> to <code>true</code> and specifying an address (<code>addr</code>), city (<code>city</code>), state (<code>st</code>), postal code (<code>zip</code>), and country (<code>ctry</code>).
 

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/jurisdiction-determination.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/jurisdiction-determination.md
@@ -92,7 +92,7 @@ Full state and country names are also supported, along with the 2 character stat
 The fallback process ignores spacing and punctuation in the city and county names.  For example, “CURRY'S CORNER”, AK is treated the same as “CURRYS CORNER” and “CURRYSCORNER”.
 
 <h4>Pro Tip</h4>
-Specify a PCode for fallback when using the embedded Geocoding functionality (<code>geo</code> = <code>true</code> in a <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/location">location</a>).  If geocoding fails to find the location, the PCode is used in the zip-only fallback.
+Specify a PCode (<code>pcd</code>) for fallback when using the embedded Geocoding functionality (<code>geo</code> = <code>true</code> in a <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/location">location</a>).  If geocoding fails to find the location, the PCode (<code>pcd</code>) is used for the jurisdiction.
 
 <h3 id="us_geo">United States Tax Request using Geocoding Example</h3>
 Geocoding functionality is being used in this example by setting <code>geo</code> to <code>true</code> and specifying an address (<code>addr</code>), city (<code>city</code>), state (<code>st</code>), postal code (<code>zip</code>), and country (<code>ctry</code>).

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/private-line.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/private-line.md
@@ -13,7 +13,7 @@ disqus: 0
   <li class="next"><a href="/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/proration/">Next<i class="glyphicon glyphicon-chevron-right"></i></a></li>
 </ul>
 
-The Private Line (<code>plsp</code>) key provides you with the ability to obtain taxes for a private line transaction.  Simply provide a percentage in the form of a decimal to indicate the percentage which applies to the origination (<code>from</code>) point. Any remaining charges are then applied to the termination (<code>to</code>) point.
+The Private Line Split (<code>plsp</code>) key provides you with the ability to obtain taxes for a private line transaction.  Simply provide a percentage in the form of a decimal to indicate the percentage which applies to the origination (<code>from</code>) point. Any remaining charges are then applied to the termination (<code>to</code>) point.
 
 For example:
 <ul class="dev-guide-list">
@@ -21,8 +21,10 @@ For example:
     <li>A <code>plsp</code> of <code>0.25</code> means 25% of the taxes are attributed to Point 'A', the remaining 75% to Point 'Z'</li>
 </ul>
 
+Remove the Private Line Split (<code>plsp</code>) key from the <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/line-item"> line item</a> (<code>itms</code>) if you don't want to use the Private Line functionality.  Setting <code>plsp</code> to 0 is interpreted as a private line split of 0% for Point 'A' and 100% for Point 'Z'.
+
 <h4>Note</h4>
-Private Line functionality is not supported on a Tax Inclusive (<code>incl</code> set to <code>true</code>) <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/line-item/">line item</a>.  The following exception is thrown in the event that a <code>plsp</code> is greater than 0 while <code>incl</code> is set to <code>true</code>.  To resolve, set <code>plsp</code> to 0 or <code>incl</code> to <code>false</code>.
+Private Line functionality is not supported on a Tax Inclusive (<code>incl</code> set to <code>true</code>) <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/line-item/">line item</a> (<code>itms</code>).  The following exception is thrown in the event that a <code>plsp</code> is greater than 0 while <code>incl</code> is set to <code>true</code>.  To resolve, set <code>incl</code> to <code>false</code>.
 
 {% highlight json %}
 {
@@ -97,10 +99,10 @@ Point 'A' is Louisville, KY while Point 'Z' is Irving, TX.  A 50% Private Line s
 {% endhighlight %}
 
 <h4>Response</h4>
-Taxes for both Point 'A' and Point 'B' are returned.
+Taxes for both Point 'A' and Point 'Z' are returned.
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse1">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse1">View the Response JSON</a>
   <div id="collapse1" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/proration.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/proration.md
@@ -20,10 +20,11 @@ A few things to keep in mind:
     <li>If prorating <b>is not</b> allowed on a tax, the full amount is taxed.</li>
     <li>If prorating <b>is</b> allowed on a tax, the fixed or per line tax applicable to the service will be returned, multiplied by the percentage supplied.</li>
     <li>If the proration is being used for an adjustment credit rather than a partial charge, the ratio of the percentage applied should reflect the portion of the month in which the service was not active.</li>
+    <li>Remove the Proration (<code>prop</code>) key from the <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/line-item"> line item</a> (<code>itms</code>) if you don't want to use Proration functionality.  Setting <code>prop</code> to 0 means 0% proration for pro-rateable fixed taxes.</li>
 </ul>
 
 <h4>Note</h4>
-Proration functionality is not supported on a Tax Inclusive (<code>incl</code> set to <code>true</code>) <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/line-item/">line item</a>.  
+Proration functionality is not supported on a Tax Inclusive (<code>incl</code> set to <code>true</code>) <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/line-item/">line item</a> (<code>itms</code>).  
 
 <h3>Proration Example</h3>
 Proration (<code>pror</code>) is set to 50% for 10 lines (<code>line</code>).
@@ -68,7 +69,7 @@ Proration (<code>pror</code>) is set to 50% for 10 lines (<code>line</code>).
 The prorated tax amounts (<code>tax</code>) are seen on Tax Type IDs (<code>tid</code>) 6 and 23.
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse1">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse1">View the Response JSON</a>
   <div id="collapse1" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/proration.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/proration.md
@@ -22,6 +22,9 @@ A few things to keep in mind:
     <li>If the proration is being used for an adjustment credit rather than a partial charge, the ratio of the percentage applied should reflect the portion of the month in which the service was not active.</li>
 </ul>
 
+<h4>Note</h4>
+Proration functionality is not supported on a Tax Inclusive (<code>incl</code> set to <code>true</code>) <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/line-item/">line item</a>.  
+
 <h3>Proration Example</h3>
 Proration (<code>pror</code>) is set to 50% for 10 lines (<code>line</code>).
 

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/tax-inclusive.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/tax-inclusive.md
@@ -88,7 +88,7 @@ In this example, Line Item 001 is designated as TaxInclusive (<code>incl</code> 
 The base sale amount (<code>base</code>) is set to 87.64509.  The desired total charge (100) = base sale amount (87.64509) + total taxes returned (12.35491).
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse1">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse1">View the Response JSON</a>
   <div id="collapse1" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}
@@ -313,7 +313,7 @@ In this example, Line Item 001 and Line Item 002 are designated as TaxInclusive 
 The base sale amount (<code>base</code>) is set for Line Item 001 and Line Item 002, but not for Line Item 003 (<code>incl</code> = <code>true</code>).
 
 <div class="panel-group">
-  <a data-toggle="collapse" href="#collapse2">View the Response JSON</a>
+  <a class="dev-guide-link" data-toggle="collapse" href="#collapse2">View the Response JSON</a>
   <div id="collapse2" class="panel-collapse collapse">
     <div class="panel-body">
 {% highlight json %}

--- a/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/tax-inclusive.md
+++ b/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/tax-inclusive.md
@@ -28,6 +28,13 @@ The desired total must be a positive value sufficiently large to cover any fixed
 
 The calculated base charge can be found for each LineItem in the BaseCharge (<code>base</code>) field in the <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/calc-taxes-response/">CalcTaxes response</a>.
 
+<h4>Note</h4>
+Tax Inclusive functionality is not supported with these line items:
+<ul class="dev-guide-list">
+  <li><a class="dev-guide-link" href="/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/private-line/">Private Line</a></li>
+  <li><a class="dev-guide-link" href="/communications/dev-guide_rest_v2/customizing-transactions/sample-transactions/proration/">Proration</a></li> 
+</ul>
+
 <h3>Tax Inclusive Example - Single Line Item</h3>
 In this example, Line Item 001 is designated as TaxInclusive (<code>incl</code> = <code>true</code>) with a desired total charge of 100 (<code>chg</code> = 100).
 

--- a/communications/dev-guide_rest_v2/reference/detailed-tax-result.md
+++ b/communications/dev-guide_rest_v2/reference/detailed-tax-result.md
@@ -157,6 +157,9 @@ The <code>Tax</code> object contains the <b>taxes</b> generated for each <a clas
 </div>
 <br>
 
+<h4>Note about Bundle Files</h4>
+Bundled tax calculations return summarized <a class="dev-guide-link" href="/communications/dev-guide_rest_v2/reference/detailed-tax-result">detailed results</a> when more than one bundle item returns the same tax type.
+
 <h3>Example</h3>
 
 {% highlight json %}

--- a/communications/dev-guide_rest_v2/reference/exemption.md
+++ b/communications/dev-guide_rest_v2/reference/exemption.md
@@ -140,7 +140,7 @@ The <code>Exemption</code> object allows you to specify <b>exemptions</b> for th
     "cat": 0,
     "dom": 3,
     "scp": 1792,
-    "exnb": false,
+    "exnb": false
   }
 ]
 {% endhighlight %}

--- a/communications/dev-guide_rest_v2/reference/line-item.md
+++ b/communications/dev-guide_rest_v2/reference/line-item.md
@@ -93,6 +93,7 @@ The <code>LineItem</code> object contains <b>detailed</b> information about a <b
                     <li>A transaction has two points: Point 'A' and Point 'Z'</li>
                     <li>A <code>plsp</code> of <code>0.25</code> means 25% of the taxes are attributed to Point 'A', the remaining 75% to Point 'Z'</li>
                 </ul>
+                Remove the key from the line item if you don't want to use the Private Line functionality.  Setting <code>plsp</code> to 0 means 0% for Point 'A' and 100% for Point 'Z'
             </td>
         </tr>
         <tr>
@@ -111,6 +112,8 @@ The <code>LineItem</code> object contains <b>detailed</b> information about a <b
             <td><code>[double]</code> Pro-rated Percentage
             <br>
             A percentage used for the pro-rated calculation of fixed taxes
+            <br/><br/>
+            Remove the key from the line item if you don't want to use Proration functionality.  Setting <code>prop</code> to 0 means 0% proration for pro-rateable fixed taxes.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION

UP-13922 - Proration not supported with Tax Inclusive.  UP-13716 - Summarized bundle results.  UP-13980 - Don't set private line or proration keys to 0 when not intending to use the functionality.  UP-13925 - Zip-Only fallback for jurisdiction Determination.

**Bundle File**
![image](https://user-images.githubusercontent.com/17029919/57637736-c34f0200-7571-11e9-9243-5ac600253a9b.png)

**Displaying Tax Results**
![image](https://user-images.githubusercontent.com/17029919/57637828-f98c8180-7571-11e9-8bd7-3c1fec198555.png)

**Jurisdiction Determination**
![image](https://user-images.githubusercontent.com/17029919/57638000-6bfd6180-7572-11e9-9f1c-918e29f2f05c.png)

**Private Line**
![image](https://user-images.githubusercontent.com/17029919/57638046-83d4e580-7572-11e9-98ab-c64c360b3ad7.png)

**Proration**
![image](https://user-images.githubusercontent.com/17029919/57638089-a2d37780-7572-11e9-96d2-666e8fe6f7b7.png)

**Tax Inclusive**
![image](https://user-images.githubusercontent.com/17029919/57638296-21c8b000-7573-11e9-9ee5-262664b2c29a.png)

**Detailed Tax Result reference**
![image](https://user-images.githubusercontent.com/17029919/57638436-63595b00-7573-11e9-9fc7-cfefcd7e260c.png)

**Exemption reference**
![image](https://user-images.githubusercontent.com/17029919/57638497-8421b080-7573-11e9-9651-a6aa2e834229.png)

**Line Item reference**
![image](https://user-images.githubusercontent.com/17029919/57638565-a7e4f680-7573-11e9-8f96-dbddd941a4a6.png)
